### PR TITLE
Update for changes to recent Octopus Deploy API

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=http://hoinfre01.yorkstreet.local

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Node script to create a release within Octopus Deploy, and optionally also deploys that release.  
 This package uses the Octopus Deploy REST API.
 
-	https://github.com/OctopusDeploy/OctopusDeploy-Api/wiki
+    https://github.com/OctopusDeploy/OctopusDeploy-Api/wiki
 
 This module was specifically created in order to initiate a release and deploy from a linux machine.
 
@@ -15,18 +15,18 @@ The primary usage was to be able to call it via the command line, but you could 
 
 Install it globally...
 
-	npm install octopus-deploy -g
-	
+    npm install octopus-deploy -g
+    
 ## Create Release
 
 Here is an example of creating a release (make into one line)
 
-	octopus-deploy-create-release 
-		--host=https://deploy.mycompany.com 
-		--apiKey=ABC-123 
-		--projectSlugOrId=my-project
-		--version=0.0.0-test-node-od-1 
-		--releaseNotes="Test release notes"
+    octopus-deploy-create-release 
+        --host=https://deploy.mycompany.com 
+        --apiKey=ABC-123 
+        --projectSlugOrId=my-project
+        --version=0.0.0-test-node-od-1 
+        --releaseNotes="Test release notes"
 
 ## Create Release and Deploy
 
@@ -34,77 +34,96 @@ Here is an example of creating a release, then deploying that release (make into
 
 `comments` and `variables` are optional
 
-	octopus-deploy-create-release-and-deploy 
-		--host=https://deploy.mycompany.com 
-		--apiKey=ABC-123 
-		--projectSlugOrId=my-project
-		--version=0.0.0-test-node-od-1 
-		--releaseNotes="Test release notes"
-		--environmentName="DEV-SERVER"
-		--comments="Automated Deploy to DEV-SERVER as post-build step"
-		--variables="{\"SourceDir\": \"\\\\\\\\SOURCESERVER\\\\MyProject\\\\0.0.0-test-node-od-1 \"}"
-	
+    octopus-deploy-create-release-and-deploy 
+        --host=https://deploy.mycompany.com 
+        --apiKey=ABC-123 
+        --projectSlugOrId=my-project
+        --version=0.0.0-test-node-od-1 
+        --releaseNotes="Test release notes"
+        --environmentName="DEV-SERVER"
+        --comments="Automated Deploy to DEV-SERVER as post-build step"
+        --variables="{\"SourceDir\": \"\\\\\\\\SOURCESERVER\\\\MyProject\\\\0.0.0-test-node-od-1 \"}"
+    
 # Library Usage
 
 If you are looking to use it as a library, you are probably looking to install it locally.
 
-	npm install octopus-deploy
+    npm install octopus-deploy
 
 This module tries to use promises whenever possible, specifically [bluebird](https://github.com/petkaantonov/bluebird) promises.
 
 ## Setup Client
 
-	var OctoDeployApi = require('octopus-deploy');
-	
-	var config = {
-		host: 'https://deploy.mycompany.com',
-		apiKey: 'ABC-123' // This is used to authorize against the REST Api
-	};
-	
-	var client = new OctoDeployApi(config);
+    var OctoDeployApi = require('octopus-deploy');
+    
+    var config = {
+        host: 'https://deploy.mycompany.com',
+        apiKey: 'ABC-123' // This is used to authorize against the REST Api
+    };
+    
+    var client = new OctoDeployApi(config);
 
 ## Helper
  
 ### Simple - Create Release And Deploy
 
-	// Release Information
-	var projectIdOrSlug = 'my-project-name';
-	var version = '1.0.0-rc-3';
-	var releaseNotes = 'Release notes for testing';
-	
-	// Deployment Information
-	var environmentName = 'DEV-SERVER';
-	var comments = 'Deploy releases-123 to DEVSERVER1';
-	// Form Value Example: Source Directory
-	var variables = {
-		'SourceDir': '\\\\SOURCESERVER\\MyProject\\1.0.0-rc-3'
-	};
-	
-	// Create Deployment
-	var deploymentPromise = client.helper.simpleCreateReleaseAndDeploy(
-		projectIdOrSlug, version, releaseNotes, environmentName, comments, variables);
-		
-	// Print out deployment
-	deploymentPromise.then(function(deployment) {
-		console.log('Deployment Created...');
-		console.log(deployment);
-	});
+The same package version will be used for all deployment steps. This depends on there existing a package of the specified version for ALL the packages referenced by the steps. 
+
+    // Release Information
+    var projectIdOrSlug = 'my-project-name';
+    var version = '1.0.0-rc.3';
+    var releaseNotes = 'Release notes for testing';
+    var packageVersion = version;
+    
+    // Deployment Information
+    var environmentName = 'DEV-SERVER';
+    var comments = 'Deploy releases-123 to DEVSERVER1';
+    // Form Value Example: Source Directory
+    var variables = {
+        'SourceDir': '\\\\SOURCESERVER\\MyProject\\1.0.0-rc-3'
+    };
+    
+    // Create Deployment
+    var deploymentPromise = client.helper.simpleCreateReleaseAndDeploy(
+        projectIdOrSlug, version, releaseNotes, environmentName, comments, variables, packageVersion);
+        
+    // Print out deployment
+    deploymentPromise.then(function(deployment) {
+        console.log('Octopus release created and deployed:');
+        console.log(deployment);
+    }, function(reason) {
+        console.log('Octopus release creation or deployment falied!');
+        console.log(reason);
+    });
 
 ## Release
 
 ### Create
 
-	var projectIdOrSlug = 'my-project-name';
-	var version = '1.0.0-rc-3';
-	var releaseNotes = 'Release notes for testing';
-	
-	releasePromise = client.release.create(projectIdOrSlug, version, releaseNotes);
-	
-	releasePromise.then(function (release) {
-		console.log('Release Created...');
-		console.log(release);
-	});
-	
+Selected packages for the deployment steps are specified more explicitly. For more information refer to [this Octopus support issue](http://help.octopusdeploy.com/discussions/problems/35372-create-release-a-version-must-be-specified-for-every-included-nuget-package).
+
+    var projectIdOrSlug = 'my-project-name';
+    var version = '1.0.0-rc.3';
+    var releaseNotes = 'Release notes for testing';
+    var selectedPackages = 
+        [{
+            "StepName": "My octopus process first step",
+            "Version": "1.0.0.0"
+        }, {
+            "StepName": "My octopus process second step",
+            "Version": "1.0.2-rc.1"
+        }];
+
+    releasePromise = client.release.create(projectIdOrSlug, version, releaseNotes, selectedPackages);
+    
+    releasePromise.then(function (release) {
+        console.log('Octopus release Created:');
+        console.log(release);
+    }, function(reason) {
+        console.log('Octopus release creation falied!');
+        console.log(reason);
+    });
+
 ## Other
 
 Other methods are exposed but I didn't want to take the time to document them right now.
@@ -116,6 +135,7 @@ Notice not all resource/methods are implemented
 - environment
 - helper (custom mashup of multiple calls)
 - project
+- process
 - release
 - variable
 
@@ -125,12 +145,12 @@ This project uses gulp for running tests.  All tests reside in the `.\test` fold
 
 To run tests...
 
-	gulp test
-	
+    gulp test
+    
 To run tests in a TDD mode with a watch...
 
-	gulp dev
-	
+    gulp dev
+    
 # TODO
 
 There are a few error cases that do not have test cases right now.

--- a/bin/create-release-and-deploy.js
+++ b/bin/create-release-and-deploy.js
@@ -3,23 +3,25 @@
 
 //// Here are the options to specify when calling this script
 var argv = require('yargs')
-	.demand('host', true)
-	.describe('host', 'The base url of your octopus deploy instance (ex: https://deploy.mycompany.com)')
-	.demand('apiKey', true)
-	.describe('apiKey', 'The api key used to connect to octopus deploy.')
-	.demand('projectSlugOrId', true)
-	.describe('projectSlugOrId', 'The id or slug of the project to perform actions against (ex. my-project or projects-123)')
-	.demand('version', true)
-	.describe('version', 'The SemVer of the release you would like to create (ex. 2.0.0-rc-4)')
-	.demand('releaseNotes', true)
-	.describe('releaseNotes', 'The notes you want to associate with this release (ex. Created release as post-build step)')
-	.demand('environmentName', true)
-	.describe('environmentName', 'Then name of the environment, if you are deploying (ex. DEV-SERVER)')
-	.demand('comments', false)
-	.describe('comments', 'Comments you want to associate with the deploy (ex. Automated Deploy to DEV-SERVER as post-build step)')
-	.demand('variables', false)
-	.describe('variables', "Variables applicable to deployment (ex. {'SourceDir': '\\\\SOURCESERVER\\MyProject\\1.0.0-rc-3'})")
-	.argv;
+    .demand('host', true)
+    .describe('host', 'The base url of your octopus deploy instance (ex: https://deploy.mycompany.com)')
+    .demand('apiKey', true)
+    .describe('apiKey', 'The api key used to connect to octopus deploy.')
+    .demand('projectSlugOrId', true)
+    .describe('projectSlugOrId', 'The id or slug of the project to perform actions against (ex. my-project or projects-123)')
+    .demand('version', true)
+    .describe('version', 'The SemVer of the release you would like to create (ex. 2.0.0-rc-4)')
+    .demand('releaseNotes', true)
+    .describe('releaseNotes', 'The notes you want to associate with this release (ex. Created release as post-build step)')
+    .demand('environmentName', true)
+    .describe('environmentName', 'Then name of the environment, if you are deploying (ex. DEV-SERVER)')
+    .demand('comments', false)
+    .describe('comments', 'Comments you want to associate with the deploy (ex. Automated Deploy to DEV-SERVER as post-build step)')
+    .demand('variables', false)
+    .describe('variables', "Variables applicable to deployment (ex. {'SourceDir': '\\\\SOURCESERVER\\MyProject\\1.0.0-rc-3'})")
+    .demand('packageVersion', false)
+    .describe('packageVersion', 'The version of the packages to deploy in this release (ALL must be of this version).')
+    .argv;
 
 // -------------------------------------------
 // Setup Client
@@ -27,8 +29,8 @@ var argv = require('yargs')
 var OctoDeployApi = require('../lib/octopus-deploy');
 
 var config = {
-	host: argv.host,
-	apiKey: argv.apiKey // This is used to authorize against the REST Api
+    host: argv.host,
+    apiKey: argv.apiKey // This is used to authorize against the REST Api
 };
 
 var client = new OctoDeployApi(config);
@@ -40,6 +42,7 @@ var client = new OctoDeployApi(config);
 var projectSlugOrId = argv.projectSlugOrId;
 var version = argv.version;
 var releaseNotes = argv.releaseNotes;
+var packageVersion = argv.packageVersion;
 
 // Deployment Information
 var environmentName = argv.environmentName;
@@ -47,25 +50,25 @@ var comments = argv.comments;
 // Form Value Example: Source Directory
 var variables;
 if (argv.variables) {
-	variables = JSON.parse(argv.variables);
+    variables = JSON.parse(argv.variables);
 }
 
-var deploymentPromise = client.helper.simpleCreateReleaseAndDeploy(projectSlugOrId, version, releaseNotes, environmentName, comments, variables);
+var deploymentPromise = client.helper.simpleCreateReleaseAndDeploy(projectSlugOrId, version, releaseNotes, environmentName, comments, variables, packageVersion);
 
 deploymentPromise.then(
-	// Success
-	function (deployment) {
-		console.log('Release and Deployment Created...');
-		console.log(deployment);
-		process.exit(0);
-	},
-	// Error
-	function (error) {
-		console.log('Error when trying to create release and deploy...');
-		if (error.error) {
-			console.log(error.error);
-		} else {
-			console.log(error);
-		}
-		process.exit(1);
-	});
+    // Success
+    function (deployment) {
+        console.log('Release and Deployment Created...');
+        console.log(deployment);
+        process.exit(0);
+    },
+    // Error
+    function (error) {
+        console.log('Error when trying to create release and deploy...');
+        if (error.error) {
+            console.log(error.error);
+        } else {
+            console.log(error);
+        }
+        process.exit(1);
+    });

--- a/bin/create-release.js
+++ b/bin/create-release.js
@@ -3,19 +3,19 @@
 
 //// Here are the options to specify when calling this script
 var argv = require('yargs')
-	.demand('host', true)
-	.describe('host', 'The base url of your octopus deploy instance (ex: https://deploy.mycompany.com)')
-	.demand('apiKey', true)
-	.describe('apiKey', 'The api key used to connect to octopus deploy.')
-	.demand('projectSlugOrId', true)
-	.describe('projectSlugOrId', 'The id or slug of the project to perform actions against (ex. my-project or projects-123)')
-	.demand('version', true)
-	.describe('version', 'The SemVer of the release you would like to create (ex. 2.0.0-rc-4)')
-	.demand('releaseNotes', true)
-	.describe('releaseNotes', 'The notes you want to associate with this release (ex. Created release as post-build step)')
-//	.demand('environmentName', false)
-//	.describe('environmentName', 'Then name of the environment, if you are deploying (ex. DEV-SERVER)')
-	.argv;
+    .demand('host', true)
+    .describe('host', 'The base url of your octopus deploy instance (ex: https://deploy.mycompany.com)')
+    .demand('apiKey', true)
+    .describe('apiKey', 'The api key used to connect to octopus deploy.')
+    .demand('projectSlugOrId', true)
+    .describe('projectSlugOrId', 'The id or slug of the project to perform actions against (ex. my-project or projects-123)')
+    .demand('version', true)
+    .describe('version', 'The SemVer of the release you would like to create (ex. 2.0.0-rc-4)')
+    .demand('releaseNotes', true)
+    .describe('releaseNotes', 'The notes you want to associate with this release (ex. Created release as post-build step)')
+    .demand('packageVersion', true)
+    .describe('packageVersion', 'The version of the packages to deploy in this release (ALL must be of this version).')
+    .argv;
 
 // -------------------------------------------
 // Setup Client
@@ -23,8 +23,8 @@ var argv = require('yargs')
 var OctoDeployApi = require('../lib/octopus-deploy');
 
 var config = {
-	host: argv.host,
-	apiKey: argv.apiKey // This is used to authorize against the REST Api
+    host: argv.host,
+    apiKey: argv.apiKey // This is used to authorize against the REST Api
 };
 
 var client = new OctoDeployApi(config);
@@ -35,23 +35,24 @@ var client = new OctoDeployApi(config);
 var projectSlugOrId = argv.projectSlugOrId;
 var version = argv.version;
 var releaseNotes = argv.releaseNotes;
+var packageVersion = argv.packageVersion;
 
-var releasePromise = client.helper.simpleCreateRelease(projectSlugOrId, version, releaseNotes);
+var releasePromise = client.helper.simpleCreateRelease(projectSlugOrId, version, releaseNotes, packageVersion);
 
 releasePromise.then(
-	// Success
-	function (release) {
-		console.log('Release Created...');
-		console.log(release);
-		process.exit(0);
-	},
-	// Error
-	function (error) {
-		console.log('Error when tyring to create release...');
-		if (error.error) {
-			console.log(error.error);
-		} else {
-			console.log(error);
-		}
-		process.exit(1);
-	});
+    // Success
+    function (release) {
+        console.log('Release Created...');
+        console.log(release);
+        process.exit(0);
+    },
+    // Error
+    function (error) {
+        console.log('Error when tyring to create release...');
+        if (error.error) {
+            console.log(error.error);
+        } else {
+            console.log(error);
+        }
+        process.exit(1);
+    });

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -28,12 +28,13 @@ var helper = function (parentClient) {
  * @param environmentId
  * @param comments
  * @param formValues
+ * @param selectedPackages
  * @returns {promise|object}
  */
-helper.prototype.createReleaseAndDeploy = function (projectId, version, releaseNotes, environmentId, comments, formValues) {
+helper.prototype.createReleaseAndDeploy = function (projectId, version, releaseNotes, environmentId, comments, formValues, selectedPackages) {
 
 	// Create Release
-	var releasePromise = client.release.create(projectId, version, releaseNotes);
+	var releasePromise = client.release.create(projectId, version, releaseNotes, selectedPackages);
 
 	// Create Deployment
 	return releasePromise.then(function (release) {
@@ -52,9 +53,10 @@ helper.prototype.createReleaseAndDeploy = function (projectId, version, releaseN
  * @param environmentName
  * @param comments
  * @param variables
+ * @param packageVersion
  * @returns {promise|Object}
  */
-helper.prototype.simpleCreateReleaseAndDeploy = function (projectSlugOrId, version, releaseNotes, environmentName, comments, variables) {
+helper.prototype.simpleCreateReleaseAndDeploy = function (projectSlugOrId, version, releaseNotes, environmentName, comments, variables, packageVersion) {
 
 	var projectId;
 	var environmentId;
@@ -75,8 +77,22 @@ helper.prototype.simpleCreateReleaseAndDeploy = function (projectSlugOrId, versi
 		return client.variable.findById(project.VariableSetId);
 	});
 
+	// Load Process
+	var processPromise = projectPromise.then(function (project) {
+
+		projectId = project.Id;
+
+		if (_.isEmpty(project.DeploymentProcessId)) {
+			BPromise.reject('DeploymentProcessId is not set on project');
+		}
+
+		return client.process.findById(project.DeploymentProcessId);
+	});
+
 	// Load Environment, Build Variables, kick off release and deploy
-	var createReleaseAndDeployPromise = variableSetPromise.then(function (variableSet) {
+	var createReleaseAndDeployPromise = Promise.all([variableSetPromise, processPromise]).then(function (returnValues) {
+
+		var variableSet = returnValues[0];
 
 		// Get environmentId for environmentName
 		var foundEnvironment = _.findWhere(variableSet.ScopeValues.Environments, {'Name': environmentName});
@@ -100,8 +116,18 @@ helper.prototype.simpleCreateReleaseAndDeploy = function (projectSlugOrId, versi
 			formValues[variableId] = variables[variableName];
 		}
 
+		var deploymentProcess = returnValues[1];
+
+		// Get deployment step names.
+		var selectedPackages = _.map(deploymentProcess.Steps, function(step) {
+			return {
+				'StepName': step.Name,
+				'Version': packageVersion		
+			}
+		});
+
 		return helper.prototype.createReleaseAndDeploy(
-			projectId, version, releaseNotes, environmentId, comments, formValues);
+			projectId, version, releaseNotes, environmentId, comments, formValues, selectedPackages);
 	});
 
 	return createReleaseAndDeployPromise;
@@ -113,21 +139,39 @@ helper.prototype.simpleCreateReleaseAndDeploy = function (projectSlugOrId, versi
  * @param projectSlugOrId
  * @param version
  * @param releaseNotes
+ * @param packageVersion
  * @returns {promise|*}
  */
-helper.prototype.simpleCreateRelease = function (projectSlugOrId, version, releaseNotes) {
+helper.prototype.simpleCreateRelease = function (projectSlugOrId, version, releaseNotes, packageVersion) {
 
 	var projectId;
 
 	// Load Project
 	var projectPromise = client.project.findBySlugOrId(projectSlugOrId);
 
-	// Create Release
-	var releasePromise = projectPromise.then(function (project) {
+	// Load Process
+	var processPromise = projectPromise.then(function (project) {
 
 		projectId = project.Id;
 
-		return client.release.create(projectId, version, releaseNotes);
+		if (_.isEmpty(project.DeploymentProcessId)) {
+			BPromise.reject('DeploymentProcessId is not set on project');
+		}
+
+		return client.process.findById(project.DeploymentProcessId);
+	});
+
+	// Create Release
+	var releasePromise = processPromise.then(function (deploymentProcess) {
+		// Get deployment step names.
+		var selectedPackages = _.map(deploymentProcess.Steps, function(step) {
+			return {
+				'StepName': step.Name,
+				'Version': packageVersion		
+			}
+		});
+		
+		return client.release.create(projectId, version, releaseNotes, selectedPackages);
 	});
 
 	return releasePromise;

--- a/lib/octopus-deploy.js
+++ b/lib/octopus-deploy.js
@@ -4,6 +4,7 @@ var deployment = require('./deployment.js');
 var environment = require('./environment.js');
 var release = require('./release.js');
 var project = require('./project.js');
+var process = require('./process.js');
 var variable = require('./variable.js');
 
 var helper = require('./helper.js');
@@ -39,6 +40,7 @@ var Client = function(config) {
 	this.environment = new environment(this);
 	this.release = new release(this);
 	this.project = new project(this);
+	this.process = new process(this);
 	this.variable = new variable(this);
 
 	this.helper = new helper(this);

--- a/lib/process.js
+++ b/lib/process.js
@@ -1,0 +1,32 @@
+/**
+ * Process resource actions
+ */
+'use strict';
+
+var internals = {};
+
+/**
+ * Constructor
+ *
+ * @param client
+ */
+var process = function (client) {
+    this.client = client;
+};
+
+/**
+ * Find a deployment process by id
+ *
+ * @param id
+ * @returns {promise|Object}
+ */
+process.prototype.findById = function(id) {
+
+    var options = {
+        uri: '/api/deploymentProcesses/' + id
+    };
+
+    return this.client.request.get(options);
+};
+
+module.exports = process;

--- a/lib/release.js
+++ b/lib/release.js
@@ -46,18 +46,21 @@ release.prototype.findByProjectIdAndVersion = function(projectId, version) {
 };
 
 /**
- * Find a release by projectId and version
+ * Create a new release
  *
  * @param projectId
  * @param version
+ * @param releaseNotes
+ * @param selectedPackages
  * @returns {promise|object}
  */
-release.prototype.create = function(projectId, version, releaseNotes) {
+release.prototype.create = function(projectId, version, releaseNotes, selectedPackages) {
 
 	var releaseBody = {
 		"ProjectId": projectId,
 		"ReleaseNotes": releaseNotes,
-		"Version": version
+		"Version": version,
+		"SelectedPackages": selectedPackages
 	};
 
 	var options = {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "octopus-deploy",
-	"version": "1.0.1",
+	"version": "2.0.0",
 	"description": "Node script to create a release within Octopus Deploy, and optionally also deploy that release. This package will use the Octopus Deploy REST API in order to be able to call it from a linux machine.",
-	"main": "./lib/client.js",
+	"main": "./lib/octopus-deploy.js",
 	"scripts": {
 		"test": "gulp test"
 	},


### PR DESCRIPTION
The Octopus Deploy API has changed recently and it requires the caller to specify the package versions to be deployed for each process step. This pull request fixes these issues:
- https://github.com/iojohnso/node-octopus-deploy/issues/3
- https://github.com/iojohnso/node-octopus-deploy/issues/2

This is a breaking change to the API hence I have upped the version number to 2.0.0.

I have also updated the test and the readme.

The large number of changes is due to replacing tabs with spaces.
