### PR TITLE
Add support for child steps

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -118,13 +118,15 @@ helper.prototype.simpleCreateReleaseAndDeploy = function (projectSlugOrId, versi
 
 		var deploymentProcess = returnValues[1];
 
-		// Get deployment step names.
-		var selectedPackages = _.map(deploymentProcess.Steps, function(step) {
-			return {
-				'StepName': step.Name,
-				'Version': packageVersion		
-			}
-		});
+		// Get deployment step names
+		var selectedPackages = _.reduce(deploymentProcess.Steps, function(packages, step) {
+			return packages.concat(_.map(step.Actions, function(action) {
+				return {
+					'StepName': action.Name,
+					'Version': packageVersion
+				}
+			}));
+		}, []);
 
 		return helper.prototype.createReleaseAndDeploy(
 			projectId, version, releaseNotes, environmentId, comments, formValues, selectedPackages);


### PR DESCRIPTION
All deploy steps have an array of at least one action. The `step.actions[0].name` matches the `step.name` in all cases, except where multiple child processes have been defined. So, it is still safe to use the array of actions rather than just the step. And, it preferred as it will also include any child steps defined in the deployment process.