### PR TITLE
allow for single options param in simpleCreateReleaseAndDeploy

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -62,6 +62,16 @@ helper.prototype.simpleCreateReleaseAndDeploy = function (projectSlugOrId, versi
 	var environmentId;
 	var formValues;
 
+	if(_.isPlainObject(projectSlugOrId)) {
+		projectSlugOrId = projectSlugOrId.projectSlugOrId;
+		version = projectSlugOrId.version;
+		releaseNotes = projectSlugOrId.releaseNotes;
+		environmentName = projectSlugOrId.environmentName;
+		comments = projectSlugOrId.comments;
+		packageVersion = projectSlugOrId.packageVersion;
+	}
+
+
 	// Load Project
 	var projectPromise = client.project.findBySlugOrId(projectSlugOrId);
 
@@ -169,10 +179,10 @@ helper.prototype.simpleCreateRelease = function (projectSlugOrId, version, relea
 		var selectedPackages = _.map(deploymentProcess.Steps, function(step) {
 			return {
 				'StepName': step.Name,
-				'Version': packageVersion		
+				'Version': packageVersion
 			}
 		});
-		
+
 		return client.release.create(projectId, version, releaseNotes, selectedPackages);
 	});
 

--- a/test/helper-test.js
+++ b/test/helper-test.js
@@ -123,6 +123,30 @@ describe('helper', function () {
 
 		});
 
+		it('should create a release and then deploy that release (via options object as only parameter)', function () {
+			var deployOptions = {
+				projectSlugOrId: 'my-project-name',
+				version: '1.0.0-rc-3',
+				releaseNotes: 'Release notes for testing',
+				environmentName: 'DEV-SERVER',
+				comments: 'Deploy releases-123 to DEVSERVER1',
+				variables: {
+					'SourceDir': '\\\\SOURCESERVER\\MyProject\\1.0.0-rc-3'
+				}
+			};
+
+			// Create Release
+			return client.helper.simpleCreateReleaseAndDeploy(deployOptions)
+				.then(function (deployment) {
+
+					expect(deployment).to.be.instanceof(Object);
+					expect(deployment.Id).to.be.a('string');
+
+					return deployment;
+				});
+
+		});
+
 	});
 
 	describe('simpleCreateRelease', function () {


### PR DESCRIPTION
Just a heads up, your tests do not run. When running `gulp dev|test` I get the following error:

```
/Users/avernacchia/Documents/not_work/node-octopus-deploy/lib/helper.js
  line 127  col 10  Missing semicolon.
  line 173  col 8   Missing semicolon.
  line 93   col 39  'Promise' is not defined.

  ⚠  3 warnings


/Users/avernacchia/Documents/not_work/node-octopus-deploy/lib/octopus-deploy.js
  line 39  col 25  A constructor name should start with an uppercase letter.
  line 40  col 26  A constructor name should start with an uppercase letter.
  line 41  col 22  A constructor name should start with an uppercase letter.
  line 42  col 22  A constructor name should start with an uppercase letter.
  line 43  col 22  A constructor name should start with an uppercase letter.
  line 44  col 23  A constructor name should start with an uppercase letter.
  line 46  col 21  A constructor name should start with an uppercase letter.

  ⚠  7 warnings



  ․

  0 passing (91ms)
  1 failing

  1) helper simpleCreateReleaseAndDeploy should create a release and then deploy that release:
     RequestError: Error: getaddrinfo ENOTFOUND deploy.mycompany.com deploy.mycompany.com:443
      at new RequestError (node_modules/request-promise/lib/errors.js:11:15)
      at Request.RP$callback [as _callback] (node_modules/request-promise/lib/rp.js:56:32)
      at self.callback (node_modules/request/request.js:186:22)
      at Request.onRequestError (node_modules/request/request.js:845:8)
      at TLSSocket.socketErrorListener (_http_client.js:308:9)
      at connectErrorNT (net.js:1016:8)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```

Allowing for the passing of one param to the `simpleCreateReleaseAndDeploy` function.

I've written a test, but I guess we'll see if it runs.