### PR TITLE
Allow using channelId for a simple release

### DIFF
--- a/bin/create-release.js
+++ b/bin/create-release.js
@@ -18,21 +18,39 @@ const args = yargs
   .describe('version', 'The SemVer of the release to create')
   .describe('releaseNotes', 'Notes to associate with the new release')
   .describe('packageVersion', 'The version of the packages to release')
+  .describe('channelId', 'The channel to be sued for the release deployments')
   .demandOption(['host', 'apiKey', 'projectSlugOrId', 'version'])
-  .example(`$0 \\\n --host=https://octopus.acme.com \\\n --apiKey=API-123 \\\n --projectSlugOrId={my-project|projects-123} \\\n --version=2.0.0-rc-4 \\\n --packageVersion=1.0.1 \\\n --releaseNotes="Created release as post-build step"`)
-  .argv
+  .example(
+    `$0 \\\n --host=https://octopus.acme.com \\\n --apiKey=API-123 \\\n --projectSlugOrId={my-project|projects-123} \\\n --version=2.0.0-rc-4 \\\n --packageVersion=1.0.1 \\\n --releaseNotes="Created release as post-build step"`
+  ).argv
 
-const { host, apiKey, projectSlugOrId, version, releaseNotes, packageVersion } = args
+const {
+  host,
+  apiKey,
+  projectSlugOrId,
+  version,
+  releaseNotes,
+  packageVersion,
+  channelId
+} = args
 
 octopusApi.init({ host, apiKey })
 
 logger.info(`Creating release for project '${projectSlugOrId}'...`)
 
-const params = { projectSlugOrId, version, releaseNotes, packageVersion }
+const params = {
+  projectSlugOrId,
+  version,
+  releaseNotes,
+  packageVersion,
+  channelId
+}
 
 createRelease(params)
   .then(release => {
-    logger.info(`Finished creating release '${release.id}'. ${projectSlugOrId} ${version}`)
+    logger.info(
+      `Finished creating release '${release.id}'. ${projectSlugOrId} ${version}`
+    )
     return release
   })
   .catch(err => {

--- a/lib/commands/simple-create-release.js
+++ b/lib/commands/simple-create-release.js
@@ -5,23 +5,34 @@ const getSelectedPackages = require('./get-selected-packages')
 const logger = require('../logger')
 const octopusApi = require('../octopus-deploy')
 
-const simpleCreateRelease = (params) => {
-  const { projectSlugOrId, version, releaseNotes } = params
+const simpleCreateRelease = params => {
+  const { projectSlugOrId, version, releaseNotes, channelId } = params
   const packageVersion = params.packageVersion || version
 
   let projectId
 
-  return getProject.execute(projectSlugOrId)
+  return getProject
+    .execute(projectSlugOrId)
     .then(project => {
       projectId = project.id
 
-      return getSelectedPackages.execute(project.deploymentProcessId, packageVersion)
+      return getSelectedPackages.execute(
+        project.deploymentProcessId,
+        packageVersion
+      )
     })
     .then(selectedPackages => {
-      const releaseParams = { projectId, version, releaseNotes, selectedPackages }
+      const releaseParams = {
+        projectId,
+        version,
+        releaseNotes,
+        selectedPackages,
+        channelId
+      }
 
       return octopusApi.releases.create(releaseParams)
-    }).then(release => {
+    })
+    .then(release => {
       logger.info(`Created release '${release.id}'`)
       return release
     })


### PR DESCRIPTION
This is necessary to be able to use a different channel when creating a new release.